### PR TITLE
Fix build error about types

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -102,7 +102,7 @@ public class MainWindow : Gtk.ApplicationWindow {
         }
     }
 
-    private bool match_keycode (int keyval, uint code) {
+    private bool match_keycode (uint keyval, uint code) {
         Gdk.KeymapKey[] keys;
         Gdk.Keymap keymap = Gdk.Keymap.get_for_display (Gdk.Display.get_default ());
         if (keymap.get_entries_for_keyval (keyval, out keys)) {


### PR DESCRIPTION
I've got the following error when trying to build the app with valac 0.46.3:

```
../src/MainWindow.vala:49.32-49.42: error: Argument 1: Cannot convert from `uint' to `int'
            if (match_keycode (Gdk.Key.F11, keycode)) {
                               ^^^^^^^^^^^
Compilation failed: 1 error(s), 0 warning(s)
```

This is because [Gdk.Key.F11 is uint](https://valadoc.org/gdk-3.0/Gdk.Key.F11.html), but `match_keycode` method accepts int as its first argument at the moment.
This PR fixes this error.
